### PR TITLE
Framework/XAudio2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+/src/DSEngine/DSEngineTestProject/test.flac

--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,8 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 /src/DSEngine/DSEngineTestProject/test.flac
+/src/DSEngine/DSEngineTestProject/test3.flac
+/src/DSEngine/DSEngineTestProject/test2.flac
+/src/DSEngine/DSEngineTestProject/test.wav
+/src/DSEngine/DSEngineTestProject/test.mp3
+/src/DSEngine/DSEngineTestProject/test.m4a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,10 @@ platform:
   - x64
 before_build:
   - nuget restore src/DSEngine/DSEngine.sln
+install:
+  - vcpkg integrate install
+  - vcpkg install boost:$(platform)-windows
+  - vcpkg install ffmpeg:$(platform)-windows
 build:
   project: src/DSEngine/DSEngine.sln
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ before_build:
   - nuget restore src/DSEngine/DSEngine.sln
 install:
   - vcpkg integrate install
-  - vcpkg install boost:$(platform)-windows
-  - vcpkg install ffmpeg:$(platform)-windows
+  - vcpkg install boost:{platform}-windows
+  - vcpkg install ffmpeg:{platform}-windows
 build:
   project: src/DSEngine/DSEngine.sln
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,10 @@ platform:
 before_build:
   - nuget restore src/DSEngine/DSEngine.sln
 install:
+  - cd C:\Tools\vcpkg
+  - git pull
+  - .\bootstrap-vcpkg.bat
+  - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg integrate install
   - cmd: if "%platform%"=="Win32" set VCPKG_ARCH=x86-windows
   - cmd: if "%platform%"=="x86"   set VCPKG_ARCH=x86-windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,11 @@ before_build:
   - nuget restore src/DSEngine/DSEngine.sln
 install:
   - vcpkg integrate install
-  - vcpkg install boost:{platform}-windows
-  - vcpkg install ffmpeg:{platform}-windows
+  - cmd: if "%platform%"=="Win32" set VCPKG_ARCH=x86-windows
+  - cmd: if "%platform%"=="x86"   set VCPKG_ARCH=x86-windows
+  - cmd: if "%platform%"=="x64"   set VCPKG_ARCH=x64-windows
+  - vcpkg install boost:%VCPKG_ARCH%
+  - vcpkg install ffmpeg:%VCPKG_ARCH%
 build:
   project: src/DSEngine/DSEngine.sln
   verbosity: minimal

--- a/src/DSEngine/DSEngine.sln.DotSettings
+++ b/src/DSEngine/DSEngine.sln.DotSettings
@@ -15,6 +15,10 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/Rules/=Typedefs/@EntryIndexedValue">&lt;NamingElement Priority="17"&gt;&lt;Descriptor Static="Indeterminate" Constexpr="Indeterminate" Const="Indeterminate" Volatile="Indeterminate" Accessibility="NOT_APPLICABLE"&gt;&lt;type Name="type alias" /&gt;&lt;type Name="typedef" /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/NamingElement&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CppNaming/Rules/=Union_0020members/@EntryIndexedValue">&lt;NamingElement Priority="12"&gt;&lt;Descriptor Static="Indeterminate" Constexpr="Indeterminate" Const="Indeterminate" Volatile="Indeterminate" Accessibility="NOT_APPLICABLE"&gt;&lt;type Name="union member" /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/NamingElement&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DSENGINEFRAMEWORK/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=DSFF/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ffmpeg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=flac/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fmpeg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HRESULT/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=DSENGINESYSTEM/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=HWND/@EntryIndexedValue">True</s:Boolean>

--- a/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj
+++ b/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj
@@ -250,7 +250,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
@@ -284,12 +284,14 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DSFDirect3D.h" />
+    <ClInclude Include="DSFFFmpeg.h" />
     <ClInclude Include="DSFLogging.h" />
     <ClInclude Include="DSFXAudio2.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="DSFDirect3D.cpp" />
+    <ClCompile Include="DSFFFmpeg.cpp" />
     <ClCompile Include="DSFLogging.cpp" />
     <ClCompile Include="DSFXAudio2.cpp" />
   </ItemGroup>

--- a/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj
+++ b/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj
@@ -55,8 +55,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
+  <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -250,7 +249,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;avcodec.lib;avdevice.lib;avfilter.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
@@ -280,7 +279,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="cpp.hint" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DSFDirect3D.h" />

--- a/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj
+++ b/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj
@@ -110,7 +110,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
@@ -154,7 +154,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
@@ -202,7 +202,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
@@ -250,7 +250,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Xaudio2.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <Manifest>
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
@@ -285,11 +285,13 @@
   <ItemGroup>
     <ClInclude Include="DSFDirect3D.h" />
     <ClInclude Include="DSFLogging.h" />
+    <ClInclude Include="DSFXAudio2.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="DSFDirect3D.cpp" />
     <ClCompile Include="DSFLogging.cpp" />
+    <ClCompile Include="DSFXAudio2.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj.filters
+++ b/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj.filters
@@ -16,7 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="cpp.hint" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DSFDirect3D.h">

--- a/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj.filters
+++ b/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClInclude Include="DSFXAudio2.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DSFFFmpeg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -40,6 +43,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DSFXAudio2.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DSFFFmpeg.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj.filters
+++ b/src/DSEngine/DSEngineFramework/DSEngineFramework.vcxproj.filters
@@ -25,6 +25,9 @@
     <ClInclude Include="DSFLogging.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DSFXAudio2.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -34,6 +37,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DSFLogging.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DSFXAudio2.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/DSEngine/DSEngineFramework/DSFFFmpeg.cpp
+++ b/src/DSEngine/DSEngineFramework/DSFFFmpeg.cpp
@@ -19,7 +19,7 @@ DSFFFmpeg::DSFFFmpeg()
 	buffer = new BYTE * [MAX_BUFFER_COUNT];
 	for (int i = 0; i < MAX_BUFFER_COUNT; ++i)
 		buffer[i] = new BYTE[MAX_AUDIO_FRAME_SIZE];
-	bufferCount = 0;
+	bufferIndex = 0;
 	eof = false;
 }
 
@@ -47,6 +47,7 @@ DSFFFmpeg::~DSFFFmpeg()
 
 void DSFFFmpeg::Init()
 {
+	// Allocate the format context
 	formatContext = avformat_alloc_context();
 
 	LOG_TRACE << "DS Engine Framework for FFmpeg Initialized!";
@@ -54,6 +55,7 @@ void DSFFFmpeg::Init()
 
 int DSFFFmpeg::OpenFile(const char* filename)
 {
+	// Open the file, save the format in format context
 	int ret = avformat_open_input(&formatContext, filename, nullptr, nullptr);
 	if (ret < 0)
 	{
@@ -61,6 +63,7 @@ int DSFFFmpeg::OpenFile(const char* filename)
 		return ret;
 	}
 
+	// Get the stream info
 	ret = avformat_find_stream_info(formatContext, nullptr);
 	if (ret < 0) {
 		LOG_ERROR << "avformat_find_stream_info error: " << AVERROR(ret);
@@ -79,21 +82,26 @@ int DSFFFmpeg::OpenFile(const char* filename)
 		return -1;
 	}
 
+	// Get the decoder
 	codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
 
 	if (codec == nullptr) {
 		LOG_ERROR << "avcodec_find_decoder codec not found. codec_id=" << audioStream->codecpar->codec_id;
 		return -1;
 	}
+
+	// Allocate the codec context
 	codecContext = avcodec_alloc_context3(codec);
 	if (codecContext == nullptr) {
 		LOG_ERROR << "avcodec_alloc_context3 error.";
 		return -1;
 	}
 
+	// WAV file fix: manually fill the codec parameters
 	avcodec_parameters_to_context(codecContext, audioStream->codecpar);
 	codecContext->channel_layout = av_get_default_channel_layout(codecContext->channels);
 
+	// Open the codec
 	ret = avcodec_open2(codecContext, codec, nullptr);
 	if (ret < 0) {
 		LOG_ERROR << "avcodec_open2 error: " << AVERROR(ret);
@@ -109,32 +117,45 @@ int DSFFFmpeg::ReadFrame()
 {
 	int ret = 0;
 
+	// Keep finding the packet until it's from the audio stream
 	do
 	{
+		// Unreferencing audio packet
 		av_packet_unref(&packet);
+		// Read frame
 		if ((ret = av_read_frame(formatContext, &packet)) < 0) {
 			if (AVERROR(ret) == AVERROR(AVERROR_EOF))
 			{
+				// End of file
 				av_packet_unref(&packet);
 				lastFrame = frame;
-				swrBufferLength = lastFrame->nb_samples * lastFrame->channels * 2; /* the 2 means S16 */
+				swrBufferLength =
+					lastFrame->nb_samples * lastFrame->channels *
+					av_get_bytes_per_sample(av_get_packed_sample_fmt(AVSampleFormat(lastFrame->format)));
 				LOG_TRACE << "End of audio file";
 			}
 			else
 			{
+				// Other errors
 				LOG_ERROR << "av_read_frame error: " << AVERROR(ret);
 			}
 			return ret;
 		}
 	} while (packet.stream_index != audioStream->index);
 
-	// decode ES
+	// Send packet to decoder
 	if ((ret = avcodec_send_packet(codecContext, &packet)) < 0) {
 		LOG_ERROR << "avcodec_send_packet error: " << AVERROR(ret);
 	}
+
+	// We don't need the packet anymore, unreferencing it
 	av_packet_unref(&packet);
+
+	// Record the old frame and allocate a new one
 	lastFrame = frame;
 	frame = av_frame_alloc();
+
+	// Get the decoded frame from decoder
 	if ((ret = avcodec_receive_frame(codecContext, frame)) < 0) {
 		if (ret != AVERROR(EAGAIN)) {
 			LOG_ERROR << "avcodec_receive_frame error: " << AVERROR(ret);
@@ -142,39 +163,70 @@ int DSFFFmpeg::ReadFrame()
 		}
 	}
 
+	// If this is the first read for getting frame data,don't set buffer length
 	if (lastFrame == nullptr)
+	{
 		swrBufferLength = 0;
+	}
 	else
-		swrBufferLength = lastFrame->nb_samples * lastFrame->channels * av_get_bytes_per_sample(av_get_packed_sample_fmt(AVSampleFormat(lastFrame->format))); /* the 2 means S16 */
+	{
+		// Buffer length = samples in frame * channels * bytes per sample
+		swrBufferLength = lastFrame->nb_samples * lastFrame->channels *
+			av_get_bytes_per_sample(av_get_packed_sample_fmt(AVSampleFormat(lastFrame->format)));
+	}
 	return ret;
 }
 
 void DSFFFmpeg::InitSoftwareResampler(int* channels, int* sampleRate, int* bytesPerSample)
 {
+	// Read a frame first to get frame format
 	ReadFrame();
 	int ret = 0;
+
+	// Allocate new software resampler
 	swr = swr_alloc();
+
 	if (swr == nullptr) {
 		LOG_ERROR << "swr_alloc error";
 		return;
 	}
+
+	// Format fix: Audio files like MP3 use floating numbers to store data.
+	// The XAudio2, however, requires signed int.
+	// If the file uses floating number, resample it as signed int with the same size.
 	AVSampleFormat outputFormat = av_get_packed_sample_fmt(AVSampleFormat(frame->format));
+	// float -> 32 bit signed int
 	if (av_get_packed_sample_fmt(AVSampleFormat(frame->format)) == AV_SAMPLE_FMT_FLT)
 		outputFormat = AV_SAMPLE_FMT_S32;
+	// double -> 64 bit signed int
 	else if (av_get_packed_sample_fmt(AVSampleFormat(frame->format)) == AV_SAMPLE_FMT_DBL)
 		outputFormat = AV_SAMPLE_FMT_S64;
 
+	// Set the input->output parameters
+	// We are not actually resampling the frame
+	// Because of a potential bug in the FFmpeg, we 
+	// let XAudio2 mastering voice do this for us.
+	// That's also why we need to output the 
+	// parameters to create the source voice.
 	av_opt_set_int(swr, "in_channel_layout", codecContext->channel_layout, 0);
 	av_opt_set_int(swr, "out_channel_layout", codecContext->channel_layout, 0);
 	av_opt_set_int(swr, "in_sample_rate", codecContext->sample_rate, 0);
 	av_opt_set_int(swr, "out_sample_rate", codecContext->sample_rate, 0);
+
+	// However, if we are facing formats that is not
+	// accepted by XAudio2, we do need to resample it.
+	// XAudio2 only accepts non-planar (packed), signed int format.
+	// We only need to make sure that the format size (bytes per sample) is the same.
 	av_opt_set_sample_fmt(swr, "in_sample_fmt", AVSampleFormat(frame->format), 0);
 	av_opt_set_sample_fmt(swr, "out_sample_fmt", outputFormat, 0);
 	ret = swr_init(swr);
+
 	if (ret < 0) {
 		LOG_ERROR << "swr_init error: " << AVERROR(ret);
 		return;
 	}
+
+	// Output the parameters for further usage
 	*channels = frame->channels;
 	*sampleRate = frame->sample_rate;
 	*bytesPerSample = av_get_bytes_per_sample(outputFormat);
@@ -182,10 +234,14 @@ void DSFFFmpeg::InitSoftwareResampler(int* channels, int* sampleRate, int* bytes
 
 int DSFFFmpeg::ResampleFrame()
 {
-	if (lastFrame == nullptr) return AVERROR_EOF;
-	int ret = swr_convert(swr, &swrBuffer, lastFrame->nb_samples, const_cast<const uint8_t * *>(lastFrame->data), lastFrame->nb_samples);
+	// First resample, lastFrame is null, do nothing
+	if (lastFrame == nullptr) return -1;
+	// Resample the frame
+	int ret = swr_convert(swr, &swrBuffer, lastFrame->nb_samples, const_cast<const uint8_t**>(lastFrame->data), lastFrame->nb_samples);
+	// We got the resampled frame buffer thus we don't need the frame anymore.
 	av_frame_unref(lastFrame);
 	av_frame_free(&lastFrame);
+
 	if (ret < 0) {
 		LOG_ERROR << "swr_convert error: " << AVERROR(ret);
 	}
@@ -194,32 +250,41 @@ int DSFFFmpeg::ResampleFrame()
 
 int DSFFFmpeg::SendBuffer(IXAudio2SourceVoice * sourceVoice)
 {
-
+	// Get state of the source voice
 	XAUDIO2_VOICE_STATE voiceState = {};
 	sourceVoice->GetState(&voiceState);
+	// If the buffer queue is not filled
 	while (voiceState.BuffersQueued < MAX_BUFFER_COUNT)
 	{
 		UINT flag = 0;
+		// Read & decode frame
 		int ret = ReadFrame();
+		// If end of file, return
 		eof = AVERROR(ret) == AVERROR(AVERROR_EOF);
 		if (ret < 0 && !eof)
 		{
 			return ret;
 		}
+		// Resample the frame
 		ret = ResampleFrame();
 		if (ret < 0 && !eof) return ret;
 		if (eof)
 		{
+			// Set the flag to end the source voice stream
 			flag = XAUDIO2_END_OF_STREAM;
 		}
-		memcpy(buffer[bufferCount], swrBuffer, swrBufferLength);
+		// Copy the buffer
+		memcpy(buffer[bufferIndex], swrBuffer, swrBufferLength);
+		// Submit the buffer
 		XAUDIO2_BUFFER xAudio2Buffer = { flag };
 		xAudio2Buffer.AudioBytes = swrBufferLength;
-		xAudio2Buffer.pAudioData = buffer[bufferCount];
+		xAudio2Buffer.pAudioData = buffer[bufferIndex];
 		sourceVoice->SubmitSourceBuffer(&xAudio2Buffer);
+		// Get the state for the queued buffer count
 		sourceVoice->GetState(&voiceState);
-		if (MAX_BUFFER_COUNT <= ++bufferCount)
-			bufferCount = 0;
+		// Change the buffer in use
+		if (MAX_BUFFER_COUNT <= ++bufferIndex)
+			bufferIndex = 0;
 		if (eof) return AVERROR_EOF;
 	}
 	return 0;

--- a/src/DSEngine/DSEngineFramework/DSFFFmpeg.cpp
+++ b/src/DSEngine/DSEngineFramework/DSFFFmpeg.cpp
@@ -1,0 +1,245 @@
+#include "DSFFFmpeg.h"
+#include "DSFLogging.h"
+
+#define MAX_BUFFER_COUNT XAUDIO2_MAX_QUEUED_BUFFERS 
+#define MAX_AUDIO_FRAME_SIZE 192000
+DSFFFmpeg::DSFFFmpeg()
+{
+	formatCtx = nullptr;
+	audioStream = nullptr;
+	codec = nullptr;
+	codecCtx = nullptr;
+	frame = nullptr;
+	swr = nullptr;
+	packet = {};
+	swr_buf_len = MAX_AUDIO_FRAME_SIZE;
+	swr_buf = new BYTE[MAX_AUDIO_FRAME_SIZE];
+	sourceVoice = nullptr;
+	eof = false;
+	buf = new BYTE * [MAX_BUFFER_COUNT];
+	for (int i = 0; i < MAX_BUFFER_COUNT; ++i)
+		buf[i] = new BYTE[MAX_AUDIO_FRAME_SIZE];
+	buf_cnt = 0;
+}
+
+
+DSFFFmpeg::~DSFFFmpeg()
+{
+	avformat_free_context(formatCtx);
+	avcodec_free_context(&codecCtx);
+	swr_free(&swr);
+	av_packet_unref(&packet);
+	av_frame_free(&frame);
+	delete[] swr_buf;
+
+	for (int i = 0; i < MAX_BUFFER_COUNT; ++i)
+		delete[] buf[i];
+	delete[] buf;
+}
+
+void DSFFFmpeg::Init()
+{
+	/*av_register_all();*/
+	formatCtx = avformat_alloc_context();
+
+	LOG_TRACE << "DS Engine Framework for FFmpeg Initialized!";
+}
+
+int DSFFFmpeg::OpenFile(const char* filename)
+{
+	int ret = avformat_open_input(&formatCtx, filename, nullptr, nullptr);
+	if (ret < 0)
+	{
+		LOG_ERROR << "FFmpeg can't open file " << filename << ", error " << AVERROR(ret);
+		return ret;
+	}
+
+	ret = avformat_find_stream_info(formatCtx, nullptr);
+	if (ret < 0) {
+		LOG_ERROR << "avformat_find_stream_info error: " << AVERROR(ret);
+		return ret;
+	}
+
+	// Find the first audio stream
+	for (unsigned int i = 0; i < formatCtx->nb_streams; i++)
+		if (formatCtx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+			audioStream = formatCtx->streams[i];
+			break;
+		}
+
+	if (audioStream == nullptr) {
+		LOG_ERROR << "Didn't find a audio stream.";
+		return -1;
+	}
+
+	codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+	if (codec == nullptr) {
+		LOG_ERROR << "avcodec_find_decoder codec not found. codec_id=" << audioStream->codecpar->codec_id;
+		return -1;
+	}
+
+	codecCtx = avcodec_alloc_context3(codec);
+	if (codecCtx == nullptr) {
+		LOG_ERROR << "avcodec_alloc_context3 error.";
+		return -1;
+	}
+
+	ret = avcodec_open2(codecCtx, codec, nullptr);
+	if (ret < 0) {
+		LOG_ERROR << "avcodec_open2 error: " << AVERROR(ret);
+		return -1;
+	}
+
+	LOG_TRACE << "File " << filename << " opened.";
+	return 0;
+}
+
+int DSFFFmpeg::ReadFrame()
+{
+	int ret = 0;
+	
+	do
+	{
+		av_packet_unref(&packet);
+		if ((ret = av_read_frame(formatCtx, &packet)) < 0) {
+			LOG_ERROR << "av_read_frame eof or error: " << AVERROR(ret);
+			LOG_INFO << "AVERROR_EOF = " << AVERROR(AVERROR_EOF);
+			return ret;
+		}
+	} while (packet.stream_index != audioStream->index);
+
+	// decode ES
+	if ((ret = avcodec_send_packet(codecCtx, &packet)) < 0) {
+		LOG_ERROR << "avcodec_send_packet error: " << AVERROR(ret);
+	}
+	av_packet_unref(&packet);
+	frame = av_frame_alloc();
+	if ((ret = avcodec_receive_frame(codecCtx, frame)) < 0) {
+		if (ret != AVERROR(EAGAIN)) {
+			LOG_ERROR << "avcodec_receive_frame error: " << AVERROR(ret);
+			return ret;
+		}
+	}
+	
+	//ret = swr_init(swr);
+	swr_buf_len = frame->nb_samples * frame->channels * 2; /* the 2 means S16 */
+
+	return ret;
+}
+
+void DSFFFmpeg::InitSoftwareResampler(int channel, int sampleRate)
+{
+	ReadFrame();
+	int ret = 0;
+	swr = swr_alloc();
+	if (swr == nullptr) {
+		LOG_ERROR << "swr_alloc error";
+		return;
+	}
+	av_opt_set_int(swr, "in_channel_layout", frame->channel_layout, 0);
+	av_opt_set_int(swr, "out_channel_layout", frame->channel_layout, 0);
+	av_opt_set_int(swr, "in_sample_rate", frame->sample_rate, 0);
+	av_opt_set_sample_fmt(swr, "in_sample_fmt", AVSampleFormat(frame->format), 0);
+	av_opt_set_int(swr, "out_sample_rate", sampleRate, 0);
+	av_opt_set_sample_fmt(swr, "out_sample_fmt", AV_SAMPLE_FMT_S16, 0);
+	ret = swr_init(swr);
+
+	if (ret < 0) {
+		LOG_ERROR << "swr_init error: " << AVERROR(ret);
+		return;
+	}
+}
+
+int DSFFFmpeg::ResampleFrame()
+{
+	int ret = swr_convert(swr, &swr_buf, frame->nb_samples, const_cast<const uint8_t * *>(frame->data), frame->nb_samples);
+	av_frame_unref(frame);
+	av_frame_free(&frame);
+	if (ret < 0) {
+		LOG_ERROR << "swr_convert error: " << AVERROR(ret);
+	}
+	return ret;
+}
+
+void DSFFFmpeg::SetXAudio2SourceVoice(IXAudio2SourceVoice * sourceVoice)
+{
+	this->sourceVoice = sourceVoice;
+}
+
+int DSFFFmpeg::BufferEnd()
+{
+	XAUDIO2_VOICE_STATE voiceState = {};
+	sourceVoice->GetState(&voiceState);
+	while (voiceState.BuffersQueued < MAX_BUFFER_COUNT && !eof)
+	{
+		int ret = ReadFrame();
+		if (ret < 0 && AVERROR(ret) != AVERROR(AVERROR_EOF))
+		{
+			return ret;
+		}
+		eof = AVERROR(ret) == AVERROR(AVERROR_EOF);
+
+		int flag;
+		if (!eof)
+		{
+			ret = ResampleFrame();
+			if (ret < 0) return ret;
+			memcpy(buf[buf_cnt], swr_buf, swr_buf_len);
+			flag = 0;
+		}		
+		else
+		{
+			memset(buf[buf_cnt], 0, MAX_AUDIO_FRAME_SIZE);
+			flag = XAUDIO2_END_OF_STREAM;
+		}
+		XAUDIO2_BUFFER buffer = { flag };
+		buffer.AudioBytes = swr_buf_len;
+		buffer.pAudioData = buf[buf_cnt];
+
+		sourceVoice->SubmitSourceBuffer(&buffer);
+		sourceVoice->GetState(&voiceState);
+		//LOG_INFO << "OnBufferEnd";
+		if (MAX_BUFFER_COUNT <= ++buf_cnt)
+			buf_cnt = 0;
+	}
+	return 0;
+}
+
+DSFVoiceCallback::DSFVoiceCallback() : event(CreateEvent(nullptr, FALSE, FALSE, nullptr))
+{
+
+}
+
+DSFVoiceCallback::~DSFVoiceCallback()
+{
+	CloseHandle(event);
+}
+
+void DSFVoiceCallback::OnStreamEnd()
+{
+}
+
+void DSFVoiceCallback::OnVoiceProcessingPassEnd()
+{
+}
+
+void DSFVoiceCallback::OnVoiceProcessingPassStart(UINT32 samples)
+{
+}
+
+void DSFVoiceCallback::OnBufferEnd(void* context)
+{
+	SetEvent(event);
+}
+
+void DSFVoiceCallback::OnBufferStart(void* context)
+{
+}
+
+void DSFVoiceCallback::OnLoopEnd(void* context)
+{
+}
+
+void DSFVoiceCallback::OnVoiceError(void* context, HRESULT Error)
+{
+}

--- a/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
+++ b/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
@@ -1,0 +1,82 @@
+/**
+ * @file DSFFFmpeg.h
+ * @author Victor Shu
+ * @brief This file declares the framework class for FFmpeg.
+ * @version 0.1
+ * @date 2019/02/26
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
+
+#pragma once
+#include "DSFXAudio2.h"
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libswresample/swresample.h>
+#include <libavutil/opt.h>
+};
+#include <xaudio2.h>
+
+#ifdef DSENGINEFRAMEWORK_EXPORTS
+#define DSENGINEFRAMEWORK_API __declspec(dllexport)
+#else
+#define DSENGINEFRAMEWORK_API __declspec(dllimport)
+#endif
+
+
+
+typedef void (*FFmpegCallback)(void*, unsigned char*, int);
+
+class DSENGINEFRAMEWORK_API DSFFFmpeg
+{
+public:
+	DSFFFmpeg();
+	~DSFFFmpeg();
+
+	void Init();
+
+	int OpenFile(const char* filename);
+
+	int ReadFrame();
+
+	void InitSoftwareResampler(int channel, int sampleRate);
+	int ResampleFrame();
+
+	void SetXAudio2SourceVoice(IXAudio2SourceVoice* sourceVoice);
+
+	int BufferEnd();
+
+private:
+	AVFormatContext* formatCtx;
+	AVStream* audioStream;
+	AVCodec* codec;
+	AVCodecContext* codecCtx;
+	AVFrame* frame;
+	AVPacket packet;
+	SwrContext* swr;
+	BYTE* swr_buf;
+	int swr_buf_len;
+	IXAudio2SourceVoice* sourceVoice;
+	BYTE** buf;
+	int buf_cnt;
+	bool eof;
+};
+
+class DSENGINEFRAMEWORK_API DSFVoiceCallback final : public IXAudio2VoiceCallback
+{
+public:
+	HANDLE event;
+	DSFVoiceCallback();
+	~DSFVoiceCallback();
+	void STDMETHODCALLTYPE OnStreamEnd() override;
+	void STDMETHODCALLTYPE OnVoiceProcessingPassEnd() override;
+	void STDMETHODCALLTYPE OnVoiceProcessingPassStart(UINT32 samples) override;
+	void STDMETHODCALLTYPE OnBufferEnd(void* context) override;
+	void STDMETHODCALLTYPE OnBufferStart(void* context) override;
+	void STDMETHODCALLTYPE OnLoopEnd(void* context) override;
+	void STDMETHODCALLTYPE OnVoiceError(void* context, HRESULT Error) override;
+};

--- a/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
+++ b/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
@@ -27,9 +27,7 @@ extern "C"
 #define DSENGINEFRAMEWORK_API __declspec(dllimport)
 #endif
 
-
-
-typedef void (*FFmpegCallback)(void*, unsigned char*, int);
+class DSFVoiceCallback;
 
 class DSENGINEFRAMEWORK_API DSFFFmpeg
 {
@@ -43,7 +41,7 @@ public:
 
 	int ReadFrame();
 
-	void InitSoftwareResampler(int channel, int sampleRate);
+	void InitSoftwareResampler(int* channels, int* sampleRate, int* bytesPerSample);
 	int ResampleFrame();
 
 	void SetXAudio2SourceVoice(IXAudio2SourceVoice* sourceVoice);
@@ -56,6 +54,7 @@ private:
 	AVCodec* codec;
 	AVCodecContext* codecCtx;
 	AVFrame* frame;
+	AVFrame* last_frame;
 	AVPacket packet;
 	SwrContext* swr;
 	BYTE* swr_buf;
@@ -63,13 +62,14 @@ private:
 	IXAudio2SourceVoice* sourceVoice;
 	BYTE** buf;
 	int buf_cnt;
-	bool eof;
+
 };
 
 class DSENGINEFRAMEWORK_API DSFVoiceCallback final : public IXAudio2VoiceCallback
 {
 public:
-	HANDLE event;
+	HANDLE bufferEvent;
+	HANDLE streamEvent;
 	DSFVoiceCallback();
 	~DSFVoiceCallback();
 	void STDMETHODCALLTYPE OnStreamEnd() override;

--- a/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
+++ b/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
@@ -10,7 +10,6 @@
  */
 
 #pragma once
-#include "DSFXAudio2.h"
 
 extern "C"
 {
@@ -44,39 +43,20 @@ public:
 	void InitSoftwareResampler(int* channels, int* sampleRate, int* bytesPerSample);
 	int ResampleFrame();
 
-	void SetXAudio2SourceVoice(IXAudio2SourceVoice* sourceVoice);
-
-	int BufferEnd();
+	int SendBuffer(IXAudio2SourceVoice* sourceVoice);
 
 private:
-	AVFormatContext* formatCtx;
+	AVFormatContext* formatContext;
 	AVStream* audioStream;
 	AVCodec* codec;
-	AVCodecContext* codecCtx;
+	AVCodecContext* codecContext;
 	AVFrame* frame;
-	AVFrame* last_frame;
+	AVFrame* lastFrame;
 	AVPacket packet;
 	SwrContext* swr;
-	BYTE* swr_buf;
-	int swr_buf_len;
-	IXAudio2SourceVoice* sourceVoice;
-	BYTE** buf;
-	int buf_cnt;
-
-};
-
-class DSENGINEFRAMEWORK_API DSFVoiceCallback final : public IXAudio2VoiceCallback
-{
-public:
-	HANDLE bufferEvent;
-	HANDLE streamEvent;
-	DSFVoiceCallback();
-	~DSFVoiceCallback();
-	void STDMETHODCALLTYPE OnStreamEnd() override;
-	void STDMETHODCALLTYPE OnVoiceProcessingPassEnd() override;
-	void STDMETHODCALLTYPE OnVoiceProcessingPassStart(UINT32 samples) override;
-	void STDMETHODCALLTYPE OnBufferEnd(void* context) override;
-	void STDMETHODCALLTYPE OnBufferStart(void* context) override;
-	void STDMETHODCALLTYPE OnLoopEnd(void* context) override;
-	void STDMETHODCALLTYPE OnVoiceError(void* context, HRESULT Error) override;
+	BYTE* swrBuffer;
+	int swrBufferLength;
+	BYTE** buffer;
+	int bufferCount;
+	bool eof;
 };

--- a/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
+++ b/src/DSEngine/DSEngineFramework/DSFFFmpeg.h
@@ -26,37 +26,136 @@ extern "C"
 #define DSENGINEFRAMEWORK_API __declspec(dllimport)
 #endif
 
-class DSFVoiceCallback;
-
+/**
+ * @brief The FFMpeg Framework of the DS Engine
+ */
 class DSENGINEFRAMEWORK_API DSFFFmpeg
 {
 public:
+	/**
+	 * @brief Construct a new DSFFFmpeg object
+	 * 
+	 * Should initialize all pointers as nullptr
+	 */
 	DSFFFmpeg();
+	/**
+	 * @brief Destroy the DSFFFmpeg object
+	 * 
+	 * Should delete or release or free all pointers
+	 */
 	~DSFFFmpeg();
 
+	/**
+	 * @brief Actual initialization of FFmpeg Framework
+	 * 
+	 */
 	void Init();
 
+	/**
+	 * @brief Open an audio file and fill the codec & format context
+	 * 
+	 * @param filename The name of the audio file to open
+	 * @return int 0 if succeeded, or other
+	 */
 	int OpenFile(const char* filename);
 
+	/**
+	 * @brief Read & decode a frame from the file
+	 * 
+	 * @return int 0 if succeeded, AVERROR_EOF if end of file, or other
+	 */
 	int ReadFrame();
 
+	/**
+	 * @brief Initialize the resampler and output the parameters
+	 * 
+	 * @param[out] channels Channel count
+	 * @param[out] sampleRate Sample rate
+	 * @param[out] bytesPerSample Bytes per sample
+	 */
 	void InitSoftwareResampler(int* channels, int* sampleRate, int* bytesPerSample);
+	/**
+	 * @brief Resample the frame
+	 * 
+	 * @return int 0 if succeeded, or other
+	 */
 	int ResampleFrame();
 
+	/**
+	 * @brief Send the decoded buffer to the XAudio2 source voice
+	 * 
+	 * @param sourceVoice The source voice used for playing the corresponding file
+	 * @return int 0 if succeeded, AVERROR_EOF if end of file, or other
+	 */
 	int SendBuffer(IXAudio2SourceVoice* sourceVoice);
 
 private:
+	/**
+	 * @brief The format context
+	 * 
+	 */
 	AVFormatContext* formatContext;
+	/**
+	 * @brief The audio stream
+	 * 
+	 */
 	AVStream* audioStream;
+	/**
+	 * @brief The codec
+	 * 
+	 */
 	AVCodec* codec;
+	/**
+	 * @brief The codec context
+	 * 
+	 */
 	AVCodecContext* codecContext;
+	/**
+	 * @brief Current frame
+	 * 
+	 */
 	AVFrame* frame;
+	/**
+	 * @brief Last frame
+	 * 
+	 * We need this because FFmpeg will return the EOF signal only **after** the final frame is read
+	 * so we are always processing the last frame
+	 * 
+	 */
 	AVFrame* lastFrame;
+	/**
+	 * @brief Audio packet
+	 * 
+	 */
 	AVPacket packet;
+	/**
+	 * @brief Resampler context
+	 * 
+	 */
 	SwrContext* swr;
+	/**
+	 * @brief Resampler buffer
+	 * 
+	 */
 	BYTE* swrBuffer;
+	/**
+	 * @brief Resampler buffer length
+	 * 
+	 */
 	int swrBufferLength;
+	/**
+	 * @brief Audio buffers
+	 * 
+	 */
 	BYTE** buffer;
-	int bufferCount;
+	/**
+	 * @brief Index of the buffer currently in use
+	 * 
+	 */
+	int bufferIndex;
+	/**
+	 * @brief End of file signal
+	 * 
+	 */
 	bool eof;
 };

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
@@ -1,0 +1,40 @@
+#include "DSFXAudio2.h"
+#include "DSFLogging.h"
+
+
+DSFXAudio2::DSFXAudio2()
+{
+	xAudio2 = nullptr;
+	masterVoice = nullptr;
+}
+
+
+DSFXAudio2::~DSFXAudio2()
+{
+	SAFE_RELEASE(xAudio2);
+	// TODO: Maybe masterVoice need to be destroyed.
+}
+
+void DSFXAudio2::Init()
+{
+	HRESULT hr = CreateXAudio2Engine();
+	if (SUCCEEDED(hr)) hr = CreateMasteringVoice();
+	if (SUCCEEDED(hr))
+		LOG_TRACE << "DS Engine Framework for XAudio2 Initialized!";
+}
+
+HRESULT DSFXAudio2::CreateXAudio2Engine()
+{
+	HRESULT hr = XAudio2Create(&xAudio2, 0, XAUDIO2_DEFAULT_PROCESSOR);
+	LOG_TRACE << "XAudio2 Engine Created.";
+	return hr;
+}
+
+HRESULT DSFXAudio2::CreateMasteringVoice()
+{
+	HRESULT hr = xAudio2->CreateMasteringVoice(&masterVoice);
+	XAUDIO2_VOICE_DETAILS voiceDetails = {};
+	masterVoice->GetVoiceDetails(&voiceDetails);
+	LOG_TRACE << "Mastering voice created with " << voiceDetails.InputChannels << " channel(s), sample rate " << voiceDetails.InputSampleRate << "Hz.";
+	return hr;
+}

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
@@ -6,6 +6,8 @@ DSFXAudio2::DSFXAudio2()
 {
 	xAudio2 = nullptr;
 	masterVoice = nullptr;
+
+	CoInitializeEx(NULL, COINIT_MULTITHREADED);
 }
 
 
@@ -56,16 +58,16 @@ unsigned int DSFXAudio2::GetMasteringVoiceChannel() const
 	return voiceDetails.InputChannels;
 }
 
-HRESULT DSFXAudio2::CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, IXAudio2VoiceCallback* pCallback) const
+HRESULT DSFXAudio2::CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, int channels, int sampleRate, int bytesPerSample, IXAudio2VoiceCallback* pCallback) const
 {
 	WAVEFORMATEXTENSIBLE wfx;
 	memset(&wfx, 0, sizeof(WAVEFORMATEXTENSIBLE));
 
 	wfx.Format.wFormatTag = WAVE_FORMAT_PCM;
-	wfx.Format.nSamplesPerSec = GetMasteringVoiceSampleRate();
-	wfx.Format.nChannels = GetMasteringVoiceChannel();
-	wfx.Format.wBitsPerSample = 16;
-	wfx.Format.nBlockAlign = wfx.Format.nChannels * 16 / 8;
+	wfx.Format.nSamplesPerSec = sampleRate;
+	wfx.Format.nChannels = channels;
+	wfx.Format.wBitsPerSample = bytesPerSample * 8;
+	wfx.Format.nBlockAlign = wfx.Format.nChannels * bytesPerSample;
 	wfx.Format.nAvgBytesPerSec = wfx.Format.nSamplesPerSec * wfx.Format.nBlockAlign;
 	wfx.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
 	wfx.Samples.wValidBitsPerSample = wfx.Format.wBitsPerSample;
@@ -78,12 +80,7 @@ HRESULT DSFXAudio2::CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, IXAud
 	return hr;
 }
 
-void DSFXAudio2::StartSourceVoice(IXAudio2SourceVoice* pSourceVoice)
+IXAudio2MasteringVoice* DSFXAudio2::GetMasteringVoice() const
 {
-	pSourceVoice->Start();
-}
-
-void DSFXAudio2::StopSourceVoice(IXAudio2SourceVoice* pSourceVoice)
-{
-	pSourceVoice->Stop();
+	return masterVoice;
 }

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
@@ -26,6 +26,9 @@ void DSFXAudio2::Init()
 HRESULT DSFXAudio2::CreateXAudio2Engine()
 {
 	HRESULT hr = XAudio2Create(&xAudio2, 0, XAUDIO2_DEFAULT_PROCESSOR);
+	XAUDIO2_DEBUG_CONFIGURATION debugConfig = {};
+	debugConfig.TraceMask |= XAUDIO2_LOG_DETAIL | XAUDIO2_LOG_WARNINGS | XAUDIO2_LOG_TIMING | XAUDIO2_LOG_MEMORY | XAUDIO2_LOG_STREAMING;
+	xAudio2->SetDebugConfiguration(&debugConfig);
 	LOG_TRACE << "XAudio2 Engine Created.";
 	return hr;
 }
@@ -35,6 +38,52 @@ HRESULT DSFXAudio2::CreateMasteringVoice()
 	HRESULT hr = xAudio2->CreateMasteringVoice(&masterVoice);
 	XAUDIO2_VOICE_DETAILS voiceDetails = {};
 	masterVoice->GetVoiceDetails(&voiceDetails);
-	LOG_TRACE << "Mastering voice created with " << voiceDetails.InputChannels << " channel(s), sample rate " << voiceDetails.InputSampleRate << "Hz.";
+	LOG_TRACE << "Mastering voice created with " << GetMasteringVoiceChannel() << " channel(s), sample rate " << GetMasteringVoiceSampleRate() << "Hz.";
 	return hr;
+}
+
+unsigned int DSFXAudio2::GetMasteringVoiceSampleRate() const
+{
+	XAUDIO2_VOICE_DETAILS voiceDetails = {};
+	masterVoice->GetVoiceDetails(&voiceDetails);
+	return voiceDetails.InputSampleRate;
+}
+
+unsigned int DSFXAudio2::GetMasteringVoiceChannel() const
+{
+	XAUDIO2_VOICE_DETAILS voiceDetails = {};
+	masterVoice->GetVoiceDetails(&voiceDetails);
+	return voiceDetails.InputChannels;
+}
+
+HRESULT DSFXAudio2::CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, IXAudio2VoiceCallback* pCallback) const
+{
+	WAVEFORMATEXTENSIBLE wfx;
+	memset(&wfx, 0, sizeof(WAVEFORMATEXTENSIBLE));
+
+	wfx.Format.wFormatTag = WAVE_FORMAT_PCM;
+	wfx.Format.nSamplesPerSec = GetMasteringVoiceSampleRate();
+	wfx.Format.nChannels = GetMasteringVoiceChannel();
+	wfx.Format.wBitsPerSample = 16;
+	wfx.Format.nBlockAlign = wfx.Format.nChannels * 16 / 8;
+	wfx.Format.nAvgBytesPerSec = wfx.Format.nSamplesPerSec * wfx.Format.nBlockAlign;
+	wfx.Format.cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+	wfx.Samples.wValidBitsPerSample = wfx.Format.wBitsPerSample;
+	masterVoice->GetChannelMask(&wfx.dwChannelMask);
+	wfx.SubFormat = KSDATAFORMAT_SUBTYPE_PCM;
+	
+	const HRESULT hr = xAudio2->CreateSourceVoice(ppSourceVoice, reinterpret_cast<WAVEFORMATEX*>(&wfx), 0, 2, pCallback);
+	if (FAILED(hr))
+		LOG_ERROR << "Failed to create source voice";
+	return hr;
+}
+
+void DSFXAudio2::StartSourceVoice(IXAudio2SourceVoice* pSourceVoice)
+{
+	pSourceVoice->Start();
+}
+
+void DSFXAudio2::StopSourceVoice(IXAudio2SourceVoice* pSourceVoice)
+{
+	pSourceVoice->Stop();
 }

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.cpp
@@ -7,7 +7,7 @@ DSFXAudio2::DSFXAudio2()
 	xAudio2 = nullptr;
 	masterVoice = nullptr;
 
-	CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 }
 
 
@@ -80,7 +80,45 @@ HRESULT DSFXAudio2::CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, int c
 	return hr;
 }
 
-IXAudio2MasteringVoice* DSFXAudio2::GetMasteringVoice() const
+DSFVoiceCallback::DSFVoiceCallback() :
+	bufferEvent(CreateEvent(nullptr, FALSE, FALSE, nullptr)),
+	streamEvent(CreateEvent(nullptr, FALSE, FALSE, nullptr))
 {
-	return masterVoice;
+
+}
+
+DSFVoiceCallback::~DSFVoiceCallback()
+{
+	CloseHandle(bufferEvent);
+	CloseHandle(streamEvent);
+}
+
+void DSFVoiceCallback::OnStreamEnd()
+{
+	SetEvent(streamEvent);
+}
+
+void DSFVoiceCallback::OnVoiceProcessingPassEnd()
+{
+}
+
+void DSFVoiceCallback::OnVoiceProcessingPassStart(UINT32 samples)
+{
+}
+
+void DSFVoiceCallback::OnBufferEnd(void* context)
+{
+	SetEvent(bufferEvent);
+}
+
+void DSFVoiceCallback::OnBufferStart(void* context)
+{
+}
+
+void DSFVoiceCallback::OnLoopEnd(void* context)
+{
+}
+
+void DSFVoiceCallback::OnVoiceError(void* context, HRESULT Error)
+{
 }

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.h
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.h
@@ -101,6 +101,33 @@ public:
 	 */
 	HRESULT CreateMasteringVoice();
 
+	/**
+	 * @brief Get the Mastering Voice Sample Rate
+	 * 
+	 * @return unsigned int Mastering voice sample rate
+	 */
+	unsigned int GetMasteringVoiceSampleRate() const;
+
+	/**
+	 * @brief Get the Mastering Voice Channel
+	 * 
+	 * @return unsigned int Mastering voice channel
+	 */
+	unsigned int GetMasteringVoiceChannel() const;
+
+	/**
+	 * @brief Create the source voice
+	 * 
+	 * @param ppSourceVoice The pointer to an output source voice pointer
+	 * @param pCallback The pointer to the client defined callback class
+	 *
+	 * @return HRESULT S_OK if creation succeed, or other
+	 */
+	HRESULT CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, IXAudio2VoiceCallback* pCallback) const;
+
+	void StartSourceVoice(IXAudio2SourceVoice* pSourceVoice);
+	void StopSourceVoice(IXAudio2SourceVoice* pSourceVoice);
+
 private:
 	/**
 	 * @brief XAudio2 Engine
@@ -112,6 +139,4 @@ private:
 	 * 
 	 */
 	IXAudio2MasteringVoice* masterVoice;
-
 };
-

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.h
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.h
@@ -119,14 +119,16 @@ public:
 	 * @brief Create the source voice
 	 * 
 	 * @param ppSourceVoice The pointer to an output source voice pointer
+	 * @param channels The target channels of the source voice
+	 * @param sampleRate The target sample rate of the source voice
+	 * @param bytesPerSample The target bytes per sample of the source voice
 	 * @param pCallback The pointer to the client defined callback class
 	 *
 	 * @return HRESULT S_OK if creation succeed, or other
 	 */
-	HRESULT CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, IXAudio2VoiceCallback* pCallback) const;
+	HRESULT CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, int channels, int sampleRate, int bytesPerSample, IXAudio2VoiceCallback* pCallback = nullptr) const;
 
-	void StartSourceVoice(IXAudio2SourceVoice* pSourceVoice);
-	void StopSourceVoice(IXAudio2SourceVoice* pSourceVoice);
+	IXAudio2MasteringVoice* GetMasteringVoice() const;
 
 private:
 	/**

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.h
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.h
@@ -122,13 +122,11 @@ public:
 	 * @param channels The target channels of the source voice
 	 * @param sampleRate The target sample rate of the source voice
 	 * @param bytesPerSample The target bytes per sample of the source voice
-	 * @param pCallback The pointer to the client defined callback class
+	 * @param pCallback The pointer to the client defined callback class, default to nullptr
 	 *
 	 * @return HRESULT S_OK if creation succeed, or other
 	 */
 	HRESULT CreateSourceVoice(IXAudio2SourceVoice** ppSourceVoice, int channels, int sampleRate, int bytesPerSample, IXAudio2VoiceCallback* pCallback = nullptr) const;
-
-	IXAudio2MasteringVoice* GetMasteringVoice() const;
 
 private:
 	/**
@@ -141,4 +139,22 @@ private:
 	 * 
 	 */
 	IXAudio2MasteringVoice* masterVoice;
+};
+
+
+
+class DSENGINEFRAMEWORK_API DSFVoiceCallback final : public IXAudio2VoiceCallback
+{
+public:
+	HANDLE bufferEvent;
+	HANDLE streamEvent;
+	DSFVoiceCallback();
+	~DSFVoiceCallback();
+	void STDMETHODCALLTYPE OnStreamEnd() override;
+	void STDMETHODCALLTYPE OnVoiceProcessingPassEnd() override;
+	void STDMETHODCALLTYPE OnVoiceProcessingPassStart(UINT32 samples) override;
+	void STDMETHODCALLTYPE OnBufferEnd(void* context) override;
+	void STDMETHODCALLTYPE OnBufferStart(void* context) override;
+	void STDMETHODCALLTYPE OnLoopEnd(void* context) override;
+	void STDMETHODCALLTYPE OnVoiceError(void* context, HRESULT Error) override;
 };

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.h
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.h
@@ -1,0 +1,117 @@
+/**
+ * @file DSFXAudio2.h
+ * @author Victor Shu
+ * @brief This file declares the framework class for XAudio2.
+ * @version 0.1
+ * @date 2019/02/26
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
+
+#pragma once
+
+#include <Windows.h>
+#include <xaudio2.h>
+#include <string>
+
+#ifndef SAFE_RELEASE
+#define SAFE_RELEASE(x) \
+   if(x != NULL)        \
+   {                    \
+      x->Release();     \
+      x = NULL;         \
+   }
+#endif
+
+#ifdef DSENGINEFRAMEWORK_EXPORTS
+#define DSENGINEFRAMEWORK_API __declspec(dllexport)
+#else
+#define DSENGINEFRAMEWORK_API __declspec(dllimport)
+#endif
+
+/**
+ * @brief The XAudio2 Framework of the DS Engine
+ */
+class DSENGINEFRAMEWORK_API DSFXAudio2
+{
+public:
+	/**
+	 * @brief Construct a new DSFXAudio2 object
+	 * 
+     * Should initialize all pointers as nullptr
+	 */
+	DSFXAudio2();
+	/**
+	 * @brief Destroy the DSFXAudio2 object
+	 * 
+     * Should delete or release or free all pointers
+	 */
+	~DSFXAudio2();
+
+	/**
+     * @brief Copy constructor of DSFXAudio2 is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSFXAudio2(const DSFXAudio2& v) = delete;
+
+    /**
+     * @brief Move constructor of DSFXAudio2 is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSFXAudio2(DSFXAudio2&& v) = delete;
+
+    /**
+     * @brief Copy assignment operator of DSFXAudio2 is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSFXAudio2& operator=(const DSFXAudio2& v) = delete;
+
+    /**
+     * @brief Move assignment operator of DSFXAudio2 is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSFXAudio2& operator=(DSFXAudio2&& v) = delete;
+
+	/**
+	 * @brief Actual initialization of XAudio2 Framework
+	 * 
+	 */
+	void Init();
+
+	/**
+	 * @brief Create the XAudio2 Engine
+	 * 
+	 * @return HRESULT S_OK if creation succeed, or other
+	 */
+	HRESULT CreateXAudio2Engine();
+
+	/**
+	 * @brief Create the mastering voice
+	 * 
+	 * @return HRESULT S_OK if creation succeed, or other
+	 */
+	HRESULT CreateMasteringVoice();
+
+private:
+	/**
+	 * @brief XAudio2 Engine
+	 * 
+	 */
+	IXAudio2* xAudio2;
+	/**
+	 * @brief Mastering Voice
+	 * 
+	 */
+	IXAudio2MasteringVoice* masterVoice;
+
+};
+

--- a/src/DSEngine/DSEngineFramework/DSFXAudio2.h
+++ b/src/DSEngine/DSEngineFramework/DSFXAudio2.h
@@ -142,19 +142,76 @@ private:
 };
 
 
-
+/**
+ * @brief Callback for XAudio2 Source Voice
+ * 
+ */
 class DSENGINEFRAMEWORK_API DSFVoiceCallback final : public IXAudio2VoiceCallback
 {
 public:
+	/**
+	 * @brief Buffer end event
+	 * 
+	 */
 	HANDLE bufferEvent;
+	/**
+	 * @brief Stream end event
+	 * 
+	 */
 	HANDLE streamEvent;
+	/**
+	 * @brief Construct a new DSFVoiceCallback object
+	 * 
+	 * Set the events
+	 * 
+	 */
 	DSFVoiceCallback();
+	/**
+	 * @brief Destroy the DSFVoiceCallback object
+	 * 
+	 * Close all events' handles
+	 * 
+	 */
 	~DSFVoiceCallback();
+	/**
+	 * @brief Called when the voice has just finished playing a contiguous audio stream
+	 * 
+	 */
 	void STDMETHODCALLTYPE OnStreamEnd() override;
+	/**
+	 * @brief Called just after the processing pass for the voice ends
+	 * 
+	 */
 	void STDMETHODCALLTYPE OnVoiceProcessingPassEnd() override;
+	/**
+	 * @brief Called during each processing pass for each voice, just before XAudio2 reads data from the voice's buffer queue.
+	 * 
+	 * @param samples The number of bytes that must be submitted immediately to avoid starvation. 
+	 */
 	void STDMETHODCALLTYPE OnVoiceProcessingPassStart(UINT32 samples) override;
+	/**
+	 * @brief Called when the voice finishes processing a buffer
+	 * 
+	 * @param context Context pointer that was assigned to the pContext member of the XAUDIO2_BUFFER structure when the buffer was submitted
+	 */
 	void STDMETHODCALLTYPE OnBufferEnd(void* context) override;
+	/**
+	 * @brief Called when the voice is about to start processing a new audio buffer
+	 * 
+	 * @param context Context pointer that was assigned to the pContext member of the XAUDIO2_BUFFER structure when the buffer was submitted
+	 */
 	void STDMETHODCALLTYPE OnBufferStart(void* context) override;
+	/**
+	 * @brief Called when the voice reaches the end position of a loop
+	 * 
+	 * @param context Context pointer that was assigned to the pContext member of the XAUDIO2_BUFFER structure when the buffer was submitted
+	 */
 	void STDMETHODCALLTYPE OnLoopEnd(void* context) override;
+	/**
+	 * @brief Called when a critical error occurs during voice processing
+	 * 
+	 * @param context Context pointer that was assigned to the pContext member of the XAUDIO2_BUFFER structure when the buffer was submitted
+	 * @param Error 
+	 */
 	void STDMETHODCALLTYPE OnVoiceError(void* context, HRESULT Error) override;
 };

--- a/src/DSEngine/DSEngineFramework/packages.config
+++ b/src/DSEngine/DSEngineFramework/packages.config
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-</packages>

--- a/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
+++ b/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
@@ -25,7 +25,7 @@ bool DSEngineApp::Init(HINSTANCE hInstance, LPWSTR lpCmdLine, HWND hWnd, int scr
 	LOG_TRACE << "DSEngineApp Init";
 
 	// Test play audio file
-	audioSystem.PlayAudioFile("test3.flac");
+	audioSystem.PlayAudioFileNonBlock("test3.flac");
 
 	return true;
 }

--- a/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
+++ b/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
@@ -23,6 +23,10 @@ bool DSEngineApp::Init(HINSTANCE hInstance, LPWSTR lpCmdLine, HWND hWnd, int scr
 	audioSystem.Init();
 	renderingSystem.Init(hWnd, screenWidth, screenHeight);
 	LOG_TRACE << "DSEngineApp Init";
+
+	// Test play audio file
+	audioSystem.PlayAudioFile("test.flac");
+
 	return true;
 }
 

--- a/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
+++ b/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
@@ -25,7 +25,7 @@ bool DSEngineApp::Init(HINSTANCE hInstance, LPWSTR lpCmdLine, HWND hWnd, int scr
 	LOG_TRACE << "DSEngineApp Init";
 
 	// Test play audio file
-	audioSystem.PlayAudioFile("test.flac");
+	audioSystem.PlayAudioFile("test3.flac");
 
 	return true;
 }

--- a/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
+++ b/src/DSEngine/DSEngineSystem/DSEngineApp.cpp
@@ -20,6 +20,7 @@ DSEngineApp::~DSEngineApp()
 
 bool DSEngineApp::Init(HINSTANCE hInstance, LPWSTR lpCmdLine, HWND hWnd, int screenWidth, int screenHeight)
 {
+	audioSystem.Init();
 	renderingSystem.Init(hWnd, screenWidth, screenHeight);
 	LOG_TRACE << "DSEngineApp Init";
 	return true;

--- a/src/DSEngine/DSEngineSystem/DSEngineApp.h
+++ b/src/DSEngine/DSEngineSystem/DSEngineApp.h
@@ -20,6 +20,7 @@
 #include <Windows.h>
 #include "DSSRendering.h"
 #include "DSFLogging.h"
+#include "DSSAudio.h"
 
 /**
  * @brief The app class. Game should derive from this
@@ -102,6 +103,11 @@ private:
 	 * @brief The Rendering System reference
 	 */
 	DSSRendering renderingSystem;
+
+	/**
+	 * @brief The Audio System reference
+	 */
+	DSSAudio audioSystem;
 };
 
 /**

--- a/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj
+++ b/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj
@@ -55,8 +55,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
+  <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -188,7 +187,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <None Include="cpp.hint" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DSEngine.h" />

--- a/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj
+++ b/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj
@@ -193,12 +193,14 @@
   <ItemGroup>
     <ClInclude Include="DSEngine.h" />
     <ClInclude Include="DSEngineApp.h" />
+    <ClInclude Include="DSSAudio.h" />
     <ClInclude Include="DSSRendering.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="DSEngine.cpp" />
     <ClCompile Include="DSEngineApp.cpp" />
+    <ClCompile Include="DSSAudio.cpp" />
     <ClCompile Include="DSSRendering.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj.filters
+++ b/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj.filters
@@ -16,7 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="cpp.hint" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DSEngineApp.h">

--- a/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj.filters
+++ b/src/DSEngine/DSEngineSystem/DSEngineSystem.vcxproj.filters
@@ -28,6 +28,9 @@
     <ClInclude Include="DSSRendering.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="DSSAudio.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -40,6 +43,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="DSSRendering.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="DSSAudio.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/DSEngine/DSEngineSystem/DSSAudio.cpp
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.cpp
@@ -14,5 +14,28 @@ DSSAudio::~DSSAudio()
 void DSSAudio::Init()
 {
 	xAudio2.Init();
+	ffmpeg.Init();
 	LOG_TRACE << "DS Engine Audio System Initialized!";
+}
+
+void DSSAudio::OpenAudioFile(const char* filename)
+{
+	ffmpeg.OpenFile(filename);
+}
+
+void DSSAudio::PlayAudioFile(const char* filename)
+{
+	ffmpeg.OpenFile(filename);
+	IXAudio2SourceVoice* sourceVoice = nullptr;
+	DSFVoiceCallback callback;
+	xAudio2.CreateSourceVoice(&sourceVoice, &callback);
+	ffmpeg.SetXAudio2SourceVoice(sourceVoice);
+	ffmpeg.InitSoftwareResampler(xAudio2.GetMasteringVoiceChannel(), xAudio2.GetMasteringVoiceSampleRate());
+	xAudio2.StartSourceVoice(sourceVoice);
+	while (true)
+	{
+		int i = ffmpeg.BufferEnd();
+		WaitForSingleObject(callback.event, INFINITE);
+		if (i != 0) break;
+	}
 }

--- a/src/DSEngine/DSEngineSystem/DSSAudio.cpp
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.cpp
@@ -18,12 +18,7 @@ void DSSAudio::Init()
 	LOG_TRACE << "DS Engine Audio System Initialized!";
 }
 
-void DSSAudio::OpenAudioFile(const char* filename)
-{
-	ffmpeg.OpenFile(filename);
-}
-
-void DSSAudio::PlayAudioFile(const char* filename)
+void DSSAudio::PlayAudioFileNonBlock(const char* filename)
 {
 	LOG_TRACE << "Creating new thread for playing audio";
 	/**
@@ -31,10 +26,10 @@ void DSSAudio::PlayAudioFile(const char* filename)
 	 *		 that contains the logging system is terminated. Will fix this
 	 *	     when implementing thread pool.
 	 */
-	playThread = boost::thread(&DSSAudio::PlayAudioFileThread, this, filename);
+	playThread = boost::thread(&DSSAudio::PlayAudioFile, this, filename);
 }
 
-void DSSAudio::PlayAudioFileThread(const char* filename)
+void DSSAudio::PlayAudioFile(const char* filename)
 {
 	ffmpeg.OpenFile(filename);
 	IXAudio2SourceVoice* sourceVoice = nullptr;

--- a/src/DSEngine/DSEngineSystem/DSSAudio.cpp
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.cpp
@@ -31,29 +31,58 @@ void DSSAudio::PlayAudioFileNonBlock(const char* filename)
 
 void DSSAudio::PlayAudioFile(const char* filename)
 {
+	// Open file with FFmpeg, and initialize codecs
 	ffmpeg.OpenFile(filename);
+
+	// The source voice to be created
 	IXAudio2SourceVoice* sourceVoice = nullptr;
+
+	// The callback will be used by the source voice
 	DSFVoiceCallback callback;
+
+	// Parameters to be used when creating source voice
 	int channels;
 	int sampleRate;
 	int bytesPerSample;
+
+	// Initialize the resampler, and get the parameters required
 	ffmpeg.InitSoftwareResampler(&channels, &sampleRate, &bytesPerSample);
+
+	// Create the source voice with the parameters
 	xAudio2.CreateSourceVoice(&sourceVoice, channels, sampleRate, bytesPerSample, &callback);
+
+	// Start the source voice
 	sourceVoice->Start();
+
 	LOG_TRACE << "Starting audio playback";
+
 	while (true)
 	{
+		// If the source voice is going to be starved, decode & send buffer with FFmpeg
 		int i = ffmpeg.SendBuffer(sourceVoice);
+
+		// Waiting for the source voice buffer to end
 		WaitForSingleObject(callback.bufferEvent, INFINITE);
+
+		// If FFmpeg hit the end of file, break the loop
 		if (i != 0)
 			break;
 	}
+
 	LOG_TRACE << "Waiting for the stream to end";
+
+	// Waiting the source voice stream to end
 	if (WaitForSingleObject(callback.streamEvent, 10000) == WAIT_TIMEOUT)
 	{
+		// If timeout, force the stream to end
 		LOG_WARNING << "Timeout. Forcing the stream to end. Please check if the XAUDIO2_END_OF_STREAM flag is properly set.";
 	}
+
+	// Stop the source voice
 	sourceVoice->Stop();
+
 	LOG_TRACE << "Stopping audio playback";
+
+	// Clear all queued buffers
 	sourceVoice->FlushSourceBuffers();
 }

--- a/src/DSEngine/DSEngineSystem/DSSAudio.cpp
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.cpp
@@ -1,0 +1,18 @@
+#include "DSSAudio.h"
+#include "DSFLogging.h"
+
+
+DSSAudio::DSSAudio()
+{
+}
+
+
+DSSAudio::~DSSAudio()
+{
+}
+
+void DSSAudio::Init()
+{
+	xAudio2.Init();
+	LOG_TRACE << "DS Engine Audio System Initialized!";
+}

--- a/src/DSEngine/DSEngineSystem/DSSAudio.h
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.h
@@ -79,11 +79,25 @@ public:
 	 */
 	void Init();
 
-	void OpenAudioFile(const char* filename);
+	/**
+	 * @brief Non-block version of playing an audio file
+     * 
+     * Creates a thread of PlayAudioFile function
+	 * 
+	 * @param filename Audio file name
+	 */
+	void PlayAudioFileNonBlock(const char* filename);
 
-	// TODO: Test function, please delete!
+    /**
+     * @brief Play an audio file
+     * 
+     * This function will block the thread. 
+     * If you want a non-block version,
+     * consider calling PlayAudioFileNonBlock.
+     * 
+     * @param filename Audio file name
+     */
 	void PlayAudioFile(const char* filename);
-	void PlayAudioFileThread(const char* filename);
 
 private:
 	/**
@@ -91,9 +105,18 @@ private:
 	 * 
 	 */
 	DSFXAudio2 xAudio2;
-
+    /**
+     * @brief The FFmpeg Framework reference
+     * 
+     * Can only play/decode one file at a time
+     * 
+     */
 	DSFFFmpeg ffmpeg;
 
+    /**
+     * @brief Thread for playing audio file.
+     * 
+     */
 	boost::thread playThread;
 };
 

--- a/src/DSEngine/DSEngineSystem/DSSAudio.h
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.h
@@ -10,13 +10,14 @@
  */
 
 #pragma once
+#include "DSFXAudio2.h"
+#include "DSFFFmpeg.h"
 
 #ifdef DSENGINESYSTEM_EXPORTS
 #define DSENGINESYSTEM_API __declspec(dllexport)
 #else
 #define DSENGINESYSTEM_API __declspec(dllimport)
 #endif
-#include "DSFXAudio2.h"
 
 /**
  * @brief The Audio System of the DS Engine
@@ -76,11 +77,17 @@ public:
 	 */
 	void Init();
 
+	void OpenAudioFile(const char* filename);
+
+	// TODO: Test function, please delete!
+	void PlayAudioFile(const char* filename);
+
 private:
 	/**
 	 * @brief The XAudio2 Framework reference
 	 * 
 	 */
 	DSFXAudio2 xAudio2;
-};
 
+	DSFFFmpeg ffmpeg;
+};

--- a/src/DSEngine/DSEngineSystem/DSSAudio.h
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.h
@@ -10,6 +10,8 @@
  */
 
 #pragma once
+
+#include <boost/thread.hpp>
 #include "DSFXAudio2.h"
 #include "DSFFFmpeg.h"
 
@@ -81,6 +83,7 @@ public:
 
 	// TODO: Test function, please delete!
 	void PlayAudioFile(const char* filename);
+	void PlayAudioFileThread(const char* filename);
 
 private:
 	/**
@@ -90,4 +93,6 @@ private:
 	DSFXAudio2 xAudio2;
 
 	DSFFFmpeg ffmpeg;
+
+	boost::thread playThread;
 };

--- a/src/DSEngine/DSEngineSystem/DSSAudio.h
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.h
@@ -1,0 +1,86 @@
+/**
+ * @file DSSAudio.h
+ * @author Victor Shu
+ * @brief This file declares the class for DSEngine Audio System.
+ * @version 0.1
+ * @date 2019/02/26
+ *
+ * @copyright Copyright (c) 2019
+ *
+ */
+
+#pragma once
+
+#ifdef DSENGINESYSTEM_EXPORTS
+#define DSENGINESYSTEM_API __declspec(dllexport)
+#else
+#define DSENGINESYSTEM_API __declspec(dllimport)
+#endif
+#include "DSFXAudio2.h"
+
+/**
+ * @brief The Audio System of the DS Engine
+ * 
+ */
+class DSENGINESYSTEM_API DSSAudio
+{
+public:
+	/**
+	 * @brief Construct a new DSSAudio object
+	 * 
+	 * Should set all pointers to nullptr
+	 */
+	DSSAudio();
+	/**
+	 * @brief Destroy the DSSAudio object
+	 * 
+	 * Should delete or release or free all pointers
+	 */
+	~DSSAudio();
+
+    /**
+     * @brief Copy constructor of DSSAudio is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSSAudio(const DSSAudio& v) = delete;
+
+    /**
+     * @brief Move constructor of DSSAudio is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSSAudio(DSSAudio&& v) = delete;
+
+    /**
+     * @brief Copy assignment operator of DSSAudio is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSSAudio& operator=(const DSSAudio& v) = delete;
+
+    /**
+     * @brief Move assignment operator of DSSAudio is deleted
+     * since the class is meant to be a singleton
+     *
+     * @param v Another instance
+     */
+    DSSAudio& operator=(DSSAudio&& v) = delete;
+
+	/**
+	 * @brief Actual initialization of the audio system
+	 * 
+	 */
+	void Init();
+
+private:
+	/**
+	 * @brief The XAudio2 Framework reference
+	 * 
+	 */
+	DSFXAudio2 xAudio2;
+};
+

--- a/src/DSEngine/DSEngineSystem/DSSAudio.h
+++ b/src/DSEngine/DSEngineSystem/DSSAudio.h
@@ -96,3 +96,4 @@ private:
 
 	boost::thread playThread;
 };
+

--- a/src/DSEngine/DSEngineSystem/DSSRendering.cpp
+++ b/src/DSEngine/DSEngineSystem/DSSRendering.cpp
@@ -19,7 +19,7 @@ DSSRendering::~DSSRendering()
 HRESULT DSSRendering::Init(HWND hWnd, unsigned int screenWidth, unsigned int screenHeight)
 {
 	HRESULT hr = direct3D.Init(hWnd, screenWidth, screenHeight);
-	LOG_TRACE << "DSEngine Rendering System Initialized!";
+	LOG_TRACE << "DS Engine Rendering System Initialized!";
 
 	// Grab the start time now that
 	// the game loop is going to run

--- a/src/DSEngine/DSEngineSystem/packages.config
+++ b/src/DSEngine/DSEngineSystem/packages.config
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-</packages>

--- a/src/DSEngine/DSEngineTestProject/DSEngineTestProject.vcxproj
+++ b/src/DSEngine/DSEngineTestProject/DSEngineTestProject.vcxproj
@@ -54,8 +54,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
+  <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -167,9 +166,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestGameApp.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/src/DSEngine/DSEngineTestProject/DSEngineTestProject.vcxproj.filters
+++ b/src/DSEngine/DSEngineTestProject/DSEngineTestProject.vcxproj.filters
@@ -27,7 +27,4 @@
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
 </Project>

--- a/src/DSEngine/DSEngineTestProject/packages.config
+++ b/src/DSEngine/DSEngineTestProject/packages.config
@@ -1,3 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-</packages>

--- a/src/DSEngine/vcpkg-restore.bat
+++ b/src/DSEngine/vcpkg-restore.bat
@@ -1,6 +1,7 @@
 @REM Store args...
 set _platform=%1%
 set _solutionDir=%2%
+set _vcpkg=vcpkg
 
 if %_platform%==Win32 ( set _platform=x86 )
 
@@ -18,12 +19,11 @@ IF %ERRORLEVEL% NEQ 0 (
         git clone https://github.com/Microsoft/vcpkg.git %_solutionDir%vcpkg
         %_solutionDir%vcpkg\bootstrap-vcpkg.bat
     )
-    ECHO Restoring package
-    %_solutionDir%vcpkg\vcpkg.exe integrate install
-    %_solutionDir%vcpkg\vcpkg.exe install boost:%_platform%-windows
+    set _vcpkg=%_solutionDir%vcpkg\vcpkg.exe
 ) else (
     ECHO Using pre-installed vcpkg.
-    ECHO Restoring package
-    vcpkg integrate install
-    vcpkg install boost:%_platform%-windows
 )
+ECHO Restoring package
+%_vcpkg% integrate install
+%_vcpkg% install boost:%_platform%-windows
+%_vcpkg% install ffmpeg:%_platform%-windows

--- a/src/DSEngine/vcpkg-restore.bat
+++ b/src/DSEngine/vcpkg-restore.bat
@@ -27,3 +27,5 @@ ECHO Restoring package
 %_vcpkg% integrate install
 %_vcpkg% install boost:%_platform%-windows
 %_vcpkg% install ffmpeg:%_platform%-windows
+
+exit /b 0


### PR DESCRIPTION
The audio framework.

The framework communicates with two libraries/sets of API: XAudio2 and FFmpeg. XAudio2 is for playing the audio, and FFmpeg is for decoding audio files.

The framework and the dummy audio system can currently play basically any format of audio files in another thread. To test, put an audio file inside the `src\DSEngine\DSEngineTestProject` folder and change the file name in `src\DSEngine\DSEngineSystem\DSEngineApp.cpp`, line 28. Don't forget to delete it afterwards or add it to `.gitignore` to prevent them from being uploaded. Format WAV, MP3, ALAC, FLAC are tested, and if any other format fails, please report.

There is a potential chance of memory leaking when exiting the app before the audio finished playing. The leakage is caused by using the logging system inside another thread. This will be fixed after the thread pool is implemented.